### PR TITLE
🔄 Cambio de nombre de usuario por comando personalizado

### DIFF
--- a/src/utils/monitorMessage.js
+++ b/src/utils/monitorMessage.js
@@ -99,7 +99,24 @@ export const monitorMessage = (
       break;
     case "cambiarusuario":
       if (username === "cuartodechenz") {
-        changeNameUser(channel, arg, username);
+        const argsSplit = taskLowercase.split("-");
+        console.log(argsSplit);
+        if (argsSplit.length !== 2) {
+          console.log(
+            "Formato incorrecto. Usa: !cambiarusuario viejoUsuario - nuevoUsuario"
+          );
+          break;
+        }
+
+        const oldUser = argsSplit[0].trim();
+        const newUser = argsSplit[1].trim();
+
+        if (!oldUser || !newUser) {
+          console.log("Ambos nombres de usuario deben estar presentes.");
+          break;
+        }
+
+        changeNameUser(channel, oldUser, newUser);
       }
       break;
 


### PR DESCRIPTION
🧠 Implementación:
- Se actualizó el case cambiarusuario para que acepte el formato: !cambiarusuario viejoUsuario - nuevoUsuario.
- Se parsea el argumento usando .split y .trim para limpiar espacios.
- Se agregó validación para verificar que ambos nombres estén presentes y que el formato sea correcto.
- Se llama a la función 'changeNameUser' pasando los parámetros correctos.

🔒 Restricción:
- Solo el usuario cuartodechenz puede ejecutar este comando.

💬 Ejemplo de uso:
!cambiarusuario tatipipi - mipiPipiLiti

✅ Resultado:
El usuario tatipipi cambio su nombre a mipiPipiLiti.

🚨 Errores posibles:
- Formato incorrecto.
- Falta uno de los nombres.
- Usuario viejo no existe.

📦 Listo para producción.